### PR TITLE
[WIP] Bounty ergoplatform/ergo#1905 - Prevent custom-scan boxes from being spent

### DIFF
--- a/submissions/beejaygee-ergo-1905.json
+++ b/submissions/beejaygee-ergo-1905.json
@@ -9,7 +9,7 @@
   "payment_currency": "SigUSD",
   "bounty_value": 500,
   "status": "in-progress",
-  "submission_date": "",
+  "submission_date": "2026-07-17",
   "expected_completion": "2026-07-24",
   "description": "Add regression coverage for custom-scan-only off-chain boxes and ensure automatic wallet payments select only boxes associated with the payments scan.",
   "review_notes": "",

--- a/submissions/beejaygee-ergo-1905.json
+++ b/submissions/beejaygee-ergo-1905.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "beejaygee",
+  "wallet_address": "9hzMoWTagjUoEfFuZ2xHgmw4zvxhoi2ux8km4LPWJ4ZZ5RTQcL8",
+  "contact_method": "GitHub: @beejaygee",
+  "work_link": "",
+  "work_title": "Prevent wallet payment from spending custom-scan-only boxes",
+  "bounty_id": "ergoplatform/ergo#1905",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1905",
+  "payment_currency": "SigUSD",
+  "bounty_value": 500,
+  "status": "in-progress",
+  "submission_date": "",
+  "expected_completion": "2026-07-24",
+  "description": "Add regression coverage for custom-scan-only off-chain boxes and ensure automatic wallet payments select only boxes associated with the payments scan.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Reservation

Reserves [ergoplatform/ergo#1905](https://github.com/ergoplatform/ergo/issues/1905) for `beejaygee`.

Planned work:

- add focused regression coverage for custom-scan-only off-chain boxes;
- ensure automatic wallet payments select only boxes associated with `PaymentsScanId`;
- verify wallet unspent-box reporting and automatic selection remain consistent.

Expected completion: **2026-07-24**.

Payout: **500 SigUSD** to the native Ergo address recorded in the submission JSON.

Validation: `PYTHON_BIN=python3 ./test.sh` — **35 passed**.
