### PR TITLE
Create ergoplatform-ergo-1884.json (reservation, 500 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-1884.json
+++ b/submissions/ergoplatform-ergo-1884.json
@@ -10,7 +10,7 @@
   "bounty_value": 500.0,
   "status": "in-progress",
   "submission_date": "2026-07-31",
-  "expected_completion": "2026-08-15",
+  "expected_completion": "2026-09-15",
   "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2450 (open, awaiting review).",
   "review_notes": "",
   "payment_tx_id": "",

--- a/submissions/ergoplatform-ergo-1884.json
+++ b/submissions/ergoplatform-ergo-1884.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2450",
+  "work_title": "Fee estimation APIs getExpectedWaitTime/getRecommendedFee return invalid values",
+  "bounty_id": "ergoplatform/ergo#1884",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1884",
+  "payment_currency": "SigUSD",
+  "bounty_value": 500.0,
+  "status": "in-progress",
+  "submission_date": "2026-07-31",
+  "expected_completion": "2026-08-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2450 (open, awaiting review).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — *upstream PR is open, not merged yet*
- [ ] Paid claims include `payment_tx_id` and `payment_date`

## Notes

Reservation for [ergoplatform/ergo#1884](https://github.com/ergoplatform/ergo/issues/1884) — *Fee estimation APIs getExpectedWaitTime/getRecommendedFee return invalid values* (500 SigUSD).

Work submitted upstream as [ergo#2450](https://github.com/ergoplatform/ergo/pull/2450) (open, awaiting review): `getExpectedWaitTime` now derives its estimate from the same mempool fee histogram used by `getRecommendedFee`, making the two endpoints mutually consistent, and the position-based fallback is bounded by the statistics measurement window so stuck transactions can no longer produce the ~20-year estimates reported in the issue. Four new tests in `ErgoMemPoolSpec` cover the fee-estimation API, which previously had none.

Will switch this submission to `awaiting-review` once the upstream PR is merged.