### PR TITLE
Create ergoplatform-ergo-1905.json (reservation, 500 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-1905.json
+++ b/submissions/ergoplatform-ergo-1905.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2451",
+  "work_title": "/wallet/payment/send is trying to spend custom scan boxes",
+  "bounty_id": "ergoplatform/ergo#1905",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1905",
+  "payment_currency": "SigUSD",
+  "bounty_value": 500.0,
+  "status": "in-progress",
+  "submission_date": "2026-07-31",
+  "expected_completion": "2026-08-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2451 (open, awaiting review).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — *upstream PR is open, not merged yet*
- [ ] Paid claims include `payment_tx_id` and `payment_date`

## Notes

Reservation for [ergoplatform/ergo#1905](https://github.com/ergoplatform/ergo/issues/1905) — */wallet/payment/send is trying to spend custom scan boxes* (500 SigUSD).

Work submitted upstream as [ergo#2451](https://github.com/ergoplatform/ergo/pull/2451) (open, awaiting review): `OffChainRegistry.offChainBoxes` holds the unconfirmed boxes of *all* scans, so boxes tracked only by an external application scan were spendable by wallet transactions. A new `walletOffChainBoxes` (payments scan only) is now used by `getBoxesToSpend` and `getWalletBoxes`, while the scan APIs keep seeing their own unconfirmed boxes. Covered by a new property in `ErgoWalletServiceSpec`.

Will switch this submission to `awaiting-review` once the upstream PR is merged.