### PR TITLE
Create ergoplatform-sigmastate-interpreter-1037.json (reservation, 200 ERG)

### DIFF
--- a/submissions/ergoplatform-sigmastate-interpreter-1037.json
+++ b/submissions/ergoplatform-sigmastate-interpreter-1037.json
@@ -10,8 +10,8 @@
   "bounty_value": 200.0,
   "status": "in-progress",
   "submission_date": "2026-07-31",
-  "expected_completion": "2026-08-15",
-  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/sigmastate-interpreter/pull/1176 (open, CI green).",
+  "expected_completion": "2026-09-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/sigmastate-interpreter/pull/1176 (open, awaiting review).",
   "review_notes": "",
   "payment_tx_id": "",
   "payment_date": ""

--- a/submissions/ergoplatform-sigmastate-interpreter-1037.json
+++ b/submissions/ergoplatform-sigmastate-interpreter-1037.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/sigmastate-interpreter/pull/1176",
+  "work_title": "compiler level util functions",
+  "bounty_id": "ergoplatform/sigmastate-interpreter#1037",
+  "original_issue_link": "https://github.com/ergoplatform/sigmastate-interpreter/issues/1037",
+  "payment_currency": "ERG",
+  "bounty_value": 200.0,
+  "status": "in-progress",
+  "submission_date": "2026-07-31",
+  "expected_completion": "2026-08-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/sigmastate-interpreter/pull/1176 (open, CI green).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — *upstream PR is open, not merged yet*
- [ ] Paid claims include `payment_tx_id` and `payment_date`

## Notes

Reservation for [ergoplatform/sigmastate-interpreter#1037](https://github.com/ergoplatform/sigmastate-interpreter/issues/1037) — *compiler level util functions* (200 ERG).

Work submitted upstream as [sigmastate-interpreter#1176](https://github.com/ergoplatform/sigmastate-interpreter/pull/1176) (open, CI green on Scala 2.11/2.12/2.13 + JS): the six requested helpers are added as predefined global functions of the ErgoScript frontend, expanded at compile time into existing ErgoTree nodes, so no consensus-critical code is touched — addressing the review feedback that closed the earlier attempt in #1086. Covered by 20 tests in a new `UtilFunctionsSpecification`.

Will switch this submission to `awaiting-review` once the upstream PR is merged.