### PR TITLE
Create ergoplatform-explorer-backend-264.json (reservation, 100 ERG)

### DIFF
--- a/submissions/ergoplatform-explorer-backend-264.json
+++ b/submissions/ergoplatform-explorer-backend-264.json
@@ -10,8 +10,8 @@
   "bounty_value": 100.0,
   "status": "in-progress",
   "submission_date": "2026-07-31",
-  "expected_completion": "2026-08-15",
-  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/explorer-backend/pull/286 (open).",
+  "expected_completion": "2026-09-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/explorer-backend/pull/286 (open, awaiting review).",
   "review_notes": "",
   "payment_tx_id": "",
   "payment_date": ""

--- a/submissions/ergoplatform-explorer-backend-264.json
+++ b/submissions/ergoplatform-explorer-backend-264.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/explorer-backend/pull/286",
+  "work_title": "Input context extension",
+  "bounty_id": "ergoplatform/explorer-backend#264",
+  "original_issue_link": "https://github.com/ergoplatform/explorer-backend/issues/264",
+  "payment_currency": "ERG",
+  "bounty_value": 100.0,
+  "status": "in-progress",
+  "submission_date": "2026-07-31",
+  "expected_completion": "2026-08-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/explorer-backend/pull/286 (open).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — *upstream PR is open, not merged yet*
- [ ] Paid claims include `payment_tx_id` and `payment_date`

## Notes

Reservation for [ergoplatform/explorer-backend#264](https://github.com/ergoplatform/explorer-backend/issues/264) — *Input context extension* (100 ERG).

Work submitted upstream as [explorer-backend#286](https://github.com/ergoplatform/explorer-backend/pull/286) (open): the v1 API never exposed the spending proof context extension of transaction inputs, although it is already indexed (`node_inputs.extension`) and carried by the `Input` DB model. `InputInfo` now includes an `extension: Json` field next to `spendingProof`, matching the node's payload shape.

Will switch this submission to `awaiting-review` once the upstream PR is merged.