### PR TITLE
Reserve ergoplatform/ergo#2213 - unite p2sAddress and p2shAddress

### DIFF
--- a/submissions/beejaygee-ergo-2213.json
+++ b/submissions/beejaygee-ergo-2213.json
@@ -2,7 +2,7 @@
   "contributor": "beejaygee",
   "wallet_address": "9hzMoWTagjUoEfFuZ2xHgmw4zvxhoi2ux8km4LPWJ4ZZ5RTQcL8",
   "contact_method": "GitHub: @beejaygee",
-  "work_link": "",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2454",
   "work_title": "Unite script/p2sAddress & script/p2shAddress",
   "bounty_id": "ergoplatform/ergo#2213",
   "original_issue_link": "https://github.com/ergoplatform/ergo/issues/2213",

--- a/submissions/beejaygee-ergo-2213.json
+++ b/submissions/beejaygee-ergo-2213.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "beejaygee",
+  "wallet_address": "9hzMoWTagjUoEfFuZ2xHgmw4zvxhoi2ux8km4LPWJ4ZZ5RTQcL8",
+  "contact_method": "GitHub: @beejaygee",
+  "work_link": "",
+  "work_title": "Unite script/p2sAddress & script/p2shAddress",
+  "bounty_id": "ergoplatform/ergo#2213",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/2213",
+  "payment_currency": "SigUSD",
+  "bounty_value": 100,
+  "status": "in-progress",
+  "submission_date": "2026-08-01",
+  "expected_completion": "2026-08-01",
+  "description": "Extracted shared boilerplate from ScriptApiRoute's p2sAddressR and p2shAddressR into a single compiledAddressR(wrapAddress) helper parameterized by Pay2SAddress.apply/Pay2SHAddress.apply. Behavior-preserving refactor: all 10 existing tests in ScriptApiRouteSpec pass unchanged (verified in a sandboxed Docker build against upstream master).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reserves [ergoplatform/ergo#2213](https://github.com/ergoplatform/ergo/issues/2213) for `beejaygee` (100 SigUSD).

Work already complete and submitted: [ergoplatform/ergo#2454](https://github.com/ergoplatform/ergo/pull/2454) — extracts the shared implementation behind `p2sAddressR`/`p2shAddressR` into a single helper. All 10 existing tests in `ScriptApiRouteSpec` pass unchanged, verified in a sandboxed Docker build.

Note: an earlier PR for this issue (#2250) got a maintainer approval but was closed unmerged without comment, and nothing has been open against it since.