### PR TITLE
Create ergoplatform-ergo-2095.json (reservation, 100 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-2095.json
+++ b/submissions/ergoplatform-ergo-2095.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2455",
+  "work_title": "ErgoTransactionSpec is unstable",
+  "bounty_id": "ergoplatform/ergo#2095",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/2095",
+  "payment_currency": "SigUSD",
+  "bounty_value": 100.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-02",
+  "expected_completion": "2026-09-15",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2455 (open, awaiting review).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for ergoplatform/ergo#2095 (ErgoTransactionSpec is unstable).

Work is implemented and submitted upstream as ergoplatform/ergo#2455, currently open and awaiting review. Status stays `in-progress` until that PR merges.