### PR TITLE
Do not flag the first open claim on a bounty as a duplicate

### DIFF
--- a/scripts/triage_submission_prs.py
+++ b/scripts/triage_submission_prs.py
@@ -278,9 +278,9 @@ def validate_submission(
     bounty_id = normalize_bounty_id(str(data.get("bounty_id", "")).strip())
     if not bounty_id:
         bounty_id = normalize_bounty_id(str(data.get("original_issue_link", "")).strip())
-    duplicates = [n for n in bounty_claims.get(bounty_id, []) if n != pr["number"]]
+    duplicates = earlier_claims(bounty_id, pr["number"], bounty_claims)
     if bounty_id and duplicates:
-        issues.append(f"duplicate bounty claim also open in PR(s): {', '.join(f'#{n}' for n in duplicates)}")
+        issues.append(f"duplicate bounty claim, already claimed by earlier PR(s): {', '.join(f'#{n}' for n in duplicates)}")
 
     prefixed = [f"{file_path}: {issue}" for issue in issues]
     return prefixed, submission_labels(data, prefixed, linked_merged), bounty_id, linked_merged, reviewer, expected_date
@@ -319,6 +319,21 @@ def bounty_claims(submissions: dict[int, list[dict[str, Any]]]) -> dict[str, lis
             if bounty_id:
                 claims.setdefault(bounty_id, []).append(pr_number)
     return claims
+
+
+def earlier_claims(bounty_id: str, pr_number: int, claims: dict[str, list[int]]) -> list[int]:
+    """Open claims on the same bounty that were opened before this one.
+
+    Reservations are first-come, first-served, so only the claims that came first can make a later
+    one a duplicate. Flagging every claimant instead would label the first one too, and since
+    `should_close_invalid` closes on `duplicate-bounty`, two claims on the same bounty would close
+    each other and leave the bounty unclaimed.
+
+    PR numbers are assigned in creation order, so a lower number is an earlier claim.
+    """
+    if not bounty_id:
+        return []
+    return sorted(n for n in claims.get(bounty_id, []) if n < pr_number)
 
 
 def select_prs_to_triage(

--- a/src/tests/test_triage_submission_prs.py
+++ b/src/tests/test_triage_submission_prs.py
@@ -1,4 +1,4 @@
-from scripts.triage_submission_prs import bounty_claims, md_text, normalize_bounty_id, select_prs_to_triage, should_close_invalid
+from scripts.triage_submission_prs import bounty_claims, earlier_claims, md_text, normalize_bounty_id, select_prs_to_triage, should_close_invalid
 
 
 def test_scheduled_triage_selects_only_submission_prs():
@@ -31,3 +31,36 @@ def test_bounty_ids_are_normalized_for_duplicate_claims():
 
 def test_markdown_text_escapes_user_controlled_output():
     assert md_text("bad | [title]\nnext") == "bad \\| \\[title\\] next"
+
+
+def test_first_claim_on_a_bounty_is_not_a_duplicate():
+    claims = {"owner/repo#12": [43, 48]}
+
+    # the first claimant has nobody ahead of it, so it is not flagged and survives
+    assert earlier_claims("owner/repo#12", 43, claims) == []
+    # the later one is
+    assert earlier_claims("owner/repo#12", 48, claims) == [43]
+
+
+def test_competing_claims_do_not_close_each_other():
+    """Both claimants used to be labelled duplicate-bounty, and should_close_invalid closes on that
+    label, so two claims on one bounty closed each other and left the bounty unclaimed."""
+    claims = {"owner/repo#12": [43, 48]}
+
+    def closes(pr_number: int) -> bool:
+        duplicates = earlier_claims("owner/repo#12", pr_number, claims)
+        labels = ["duplicate-bounty"] if duplicates else []
+        return should_close_invalid({"labels": labels, "issues": []})
+
+    assert closes(43) is False
+    assert closes(48) is True
+
+
+def test_claims_on_different_bounties_never_collide():
+    claims = {"owner/repo#12": [43], "owner/repo#99": [48]}
+
+    assert earlier_claims("owner/repo#99", 48, claims) == []
+
+
+def test_a_submission_without_a_bounty_id_is_never_a_duplicate():
+    assert earlier_claims("", 48, {"owner/repo#12": [43]}) == []


### PR DESCRIPTION
## Type

- [ ] Bounty submission or reservation
- [x] Automation/code change
- [ ] Generated data update
- [ ] Documentation

<!-- Submission checklist omitted: no `submissions/*.json` file is touched by this PR. -->

## The bug

`validate_submission` flags a duplicate claim like this:

```python
duplicates = [n for n in bounty_claims.get(bounty_id, []) if n != pr["number"]]
if bounty_id and duplicates:
    issues.append(f"duplicate bounty claim also open in PR(s): ...")
```

The filter is `!= pr["number"]`, so when two open PRs claim the same bounty **each one sees the other** and both get `duplicate-bounty`. And `should_close_invalid` closes on that label:

```python
if labels & {"invalid-json", "missing-wallet", "duplicate-bounty"}:
    return True
```

So the two claims close each other and the bounty is left with nobody working on it — the opposite of what the check exists for. With three claimants, all three go.

Not hypothetical: #43 and #48 both claimed ergo#1905, both were labelled `duplicate-bounty`, and #48 was closed by the bot.

## The fix

Reservations are first-come, first-served, so only claims that came *first* can make a later one a duplicate. `earlier_claims` returns only those; PR numbers are assigned in creation order, so a lower number is an earlier claim. The first claimant has nobody ahead of it, is not flagged, and survives. Everything after it is still flagged and still closed — the behaviour the check was after.

The message moves with it: "already claimed by earlier PR(s): #43" says who has priority, where "also open in PR(s)" did not.

Worth saying plainly: in the #43/#48 incident this rule would have kept #43 and closed #48 — and #48 was mine. I would rather the rule be right than convenient.

## Tests

Four properties in `src/tests/test_triage_submission_prs.py`, including the closing behaviour end to end — with claims `{bounty: [43, 48]}`, `closes(43) is False` and `closes(48) is True`.

`python3 -m pytest -q src/tests/test_triage_submission_prs.py` → 8 passed. The 6 errors in `test_processor.py` are pre-existing on a clean checkout of `main` and unrelated to this change.

## One thing this deliberately does not decide

If the earliest claim goes stale — opened weeks ago, no `work_link`, no commits — this rule still gives it priority indefinitely and later claimants keep getting closed. That is a policy question (how long a reservation holds, what renews it), not a bug, so I have left it alone rather than settle it inside a bugfix. Happy to open a separate issue for it.
