### PR TITLE
Detect bounty issues with stalled, unmerged pull requests

### DIFF
--- a/.github/workflows/detect-contested-bounties.yml
+++ b/.github/workflows/detect-contested-bounties.yml
@@ -1,0 +1,65 @@
+name: Detect Contested Bounties
+
+on:
+  schedule:
+    - cron: '15 1 * * *'  # after the daily bounty update (00:00 UTC) has committed data/all.md
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Only sweep the first N issues (0 = no limit)'
+        required: false
+        default: '0'
+
+jobs:
+  detect-contested-bounties:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Sweep bounty issues for contention
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SWEEP_LIMIT: ${{ inputs.limit }}
+        run: |
+          limit="${SWEEP_LIMIT:-0}"
+          case "${limit}" in
+            ''|*[!0-9]*)
+              echo "limit input must be a non-negative integer" >&2
+              exit 2
+              ;;
+          esac
+          python scripts/detect_contested_bounties.py \
+            --write-dashboard data/contested-bounties.md \
+            --write-json data/contested_bounties.json \
+            --limit "${limit}" \
+            --exit-zero
+
+      - name: Commit dashboard
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          test -f data/contested-bounties.md || exit 0
+          git add data/contested-bounties.md data/contested_bounties.json
+          if git diff --cached --quiet; then
+            echo "No contention data changes."
+            exit 0
+          fi
+          git commit -m "Update contested bounties report"
+          # Other scheduled jobs also push to main; rebase rather than fail the run.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}), rebasing on origin/main."
+            git pull --rebase origin main
+          done
+          echo "Could not push after 3 attempts." >&2
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ python3 -m py_compile scripts/triage_submission_prs.py
 python3 -m json.tool .github/submission.schema.json >/dev/null
 GITHUB_TOKEN="$GITHUB_TOKEN" python3 scripts/triage_submission_prs.py --write-dashboard /tmp/ergo-triage.md
 GITHUB_TOKEN="$GITHUB_TOKEN" python3 scripts/update_ops_issue.py --dry-run
+GITHUB_TOKEN="$GITHUB_TOKEN" python3 scripts/detect_contested_bounties.py --write-dashboard /tmp/ergo-contested.md --limit 20
 python3 -m src.tests.run_bounty_check
 ./test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 ## Quick Links
 
-- Browse: [all bounties](/data/all.md), [new](/data/new-bounties.md), [recently active](/data/recently-active.md), [stale](/data/stale-bounties.md), [starter-sized](/data/starter-bounties.md), [high value](/data/high-value-bounties.md)
+- Browse: [all bounties](/data/all.md), [new](/data/new-bounties.md), [recently active](/data/recently-active.md), [stale](/data/stale-bounties.md), [starter-sized](/data/starter-bounties.md), [high value](/data/high-value-bounties.md), [contested](/data/contested-bounties.md)
 - Claim or reserve: open a PR adding one `submissions/*.json` file with `status: in-progress`
 - Request payment: update that submission PR to `status: awaiting-review` once the upstream work PR is merged
 - Maintainers: use [maintainer runbook](/docs/maintainer-runbook.md), [reviewer guide](/docs/reviewer-guide.md), [payment status](/submissions/payment_status.md), [payment queue](/submissions/payment_queue.md), and [triage dashboard](/submissions/triage.md)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,6 +9,7 @@ The repository uses GitHub Actions to automatically track and update the list of
 ### Automation Schedule
 
 - **Daily Updates**: The bounty list is refreshed every day at midnight UTC
+- **Contested Bounty Sweep**: Open bounty issues are checked for stalled pull requests daily at 01:15 UTC, after the bounty list has refreshed
 - **Submission PR Triage**: Submission PRs are triaged when opened/updated and again daily at 09:00 UTC
 - **Ops Status**: A weekly ops issue is updated every Monday at 09:30 UTC
 - **Manual Trigger**: Maintainers can manually run the workflow when needed
@@ -56,6 +57,7 @@ Generated outputs:
 - `data/all.md`, `data/summary.md`, `data/featured_bounties.md`, `data/high-value-bounties.md`
 - `data/new-bounties.md`, `data/recently-active.md`, `data/stale-bounties.md`, `data/starter-bounties.md`
 - `data/by_language/*.md`, `data/by_currency/*.md`, `data/by_org/*.md`
+- `data/contested-bounties.md`, `data/contested_bounties.json`
 - `submissions/payment_status.md`, `submissions/payment_queue.md`, `submissions/paid.md`, `submissions/triage.md`
 - README badges and latest-update marker
 
@@ -143,6 +145,31 @@ The weekly ops workflow (`.github/workflows/ops-status.yml`) updates a GitHub is
 
 Maintainer operating steps live in the [maintainer runbook](maintainer-runbook.md).
 
+## Contested Bounty Detection
+
+Some bounties look ideal from the listing alone -- clear scope, fair reward -- and are traps anyway: contributor after contributor opens a pull request, none of them is ever merged, and the issue stays open forever because nothing ever closes it. Comment count does not catch this; linked pull requests do.
+
+The main automation is `.github/workflows/detect-contested-bounties.yml`, backed by `scripts/detect_contested_bounties.py`. It runs after the daily bounty update, reads every open bounty from `data/all.md`, and for each one walks the issue's GitHub timeline to find pull requests that reference it. An issue with two or more open pull requests and no pull request merged in the last 180 days is flagged as contested. Both thresholds are flags (`--min-open-prs`, `--merge-window-days`).
+
+The merge window matters: a `cross-referenced` event records a *mention*, not a fix. Without a recency limit, one pull request merged years ago that happened to say "related to #123" would immunise that bounty against ever being flagged again -- and because cross-references accumulate over an issue's whole life, the oldest bounties would be the most immunised, which is exactly backwards.
+
+This is read-only: the sweep never comments, labels, or closes anything. It writes:
+
+- `data/contested-bounties.md`: a dashboard of currently contested issues
+- `data/contested_bounties.json`: the full per-issue sweep data, keyed by issue URL
+
+### Reading the report honestly
+
+Every issue record carries its own `checked` date, because the sweep does not always finish:
+
+- An issue **missing** from `items` has never been checked. That is not the same as clear.
+- An issue present with an **older `checked` date** was checked then, not now. Also not the same as clear.
+- A run that was cut short sets `partial: true`, and the dashboard says the rest of the board was not checked.
+
+When a run is cut short, findings for issues it did not reach are carried forward from the previous run rather than dropped, and shown with the date they were actually observed. Otherwise a single rate-limited morning would replace a report full of known traps with whatever handful of issues got through -- which reads as good news. Carried entries are discarded once their bounty leaves the board, so the report cannot accumulate ghosts.
+
+If a run produces nothing at all (no token, or every request fails), the previous report is left in place rather than overwritten with an empty one. A GitHub `403` is only treated as a rate limit when the response headers say so; a `403` from an organisation's third-party application restrictions, a SAML requirement, or a disabled repository is a single skipped issue, not a reason to abandon the rest of the sweep on every future run.
+
 ## Technical Implementation
 
 The bounty tracking is implemented in Python using the GitHub API. The main components are:
@@ -166,6 +193,7 @@ The system generates:
 - `data/recently-active.md`: most recently updated bounties
 - `data/stale-bounties.md`: old bounties with little recent activity
 - `data/starter-bounties.md`: smaller, easier-to-start bounties
+- `data/contested-bounties.md`: bounties with stalled, unmerged pull requests (see [Contested Bounty Detection](#contested-bounty-detection))
 - Language-specific Markdown files in the `data/by_language/` directory
 - Currency-specific Markdown files in the `data/by_currency/` directory
 - Organization-specific Markdown files in the `data/by_org/` directory

--- a/scripts/detect_contested_bounties.py
+++ b/scripts/detect_contested_bounties.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Flag Ergo-Bounties issues where pull requests pile up but nothing ever merges.
+
+Some bounties look ideal from the listing alone -- clear scope, fair reward,
+"good first issue" -- and are traps anyway: contributor after contributor opens
+a pull request, none of them is ever merged, and the issue stays open forever
+because nothing ever closes it. Comment count does not catch this; linked pull
+requests do.
+
+For every open bounty in `data/all.md` this script reads the issue's timeline,
+collects the pull requests that cross-reference it, and counts how many are
+open vs merged vs closed. An issue with several open, unmerged pull requests
+and no recent merge is "contested" and gets flagged in
+`data/contested-bounties.md`.
+
+Design notes, mostly about being honest when the sweep goes wrong:
+
+- Read-only against GitHub. Never comments, labels, or closes anything.
+- The timeline is paginated. Events come back oldest-first, so reading only
+  the first page would drop the most recent cross-references -- precisely on
+  the busiest issues, which are the ones most likely to be contested. Missing
+  a trap is worse than reporting a doubtful one, so we walk every page.
+- Every issue record carries its own `checked` date. An issue absent from
+  `items` has never been checked; an issue present with an old `checked` date
+  was checked then, not now. Neither is the same as "clear", and the dashboard
+  says so rather than implying a clean bill of health.
+- A partial sweep (rate limit, network trouble) keeps the previous findings
+  for the issues it did not reach this time instead of dropping them, so a bad
+  morning cannot quietly empty a report full of known traps. Carried entries
+  are shown with the date they were actually observed.
+- A merge only clears an issue if it is recent. `cross-referenced` records
+  mentions, not fixes, so one merged PR that happened to say "related to #123"
+  would otherwise immunise a bounty against ever being flagged again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+MARKER = "<!-- ergo-bounties-contested-bounties -->"
+MAX_TIMELINE_PAGES = 20  # 2000 events; a runaway guard, not an expected limit
+
+# `data/all.md`'s "Bounty" cell is `[repo](repo_url)/[title](issue_url)`. Split
+# off the repo link first, then match the title link against what is left --
+# matching greedily against the whole cell in one regex mis-captures the repo
+# link's own `]...(` as part of the title.
+BOUNTY_CELL_RE = re.compile(r"^\[([^\]]+)\]\((https://github\.com/([^/)]+)/([^/)]+))\)/(.*)$")
+TITLE_LINK_RE = re.compile(r"^\[(.*)\]\((https://github\.com/[^)]+)\)$")
+ISSUE_URL_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/issues/(\d+)$")
+
+
+class RateLimited(Exception):
+    """GitHub asked us to back off. Stop the sweep; do not burn the rest of the board."""
+
+
+class IssueUnavailable(Exception):
+    """This one issue could not be read. Skip it; the rest of the sweep is still good."""
+
+
+class GitHub:
+    def __init__(self, token: str, timeout: int = 30) -> None:
+        self.token = token
+        self.timeout = timeout
+
+    def _get(self, path: str) -> Any:
+        req = Request(
+            f"https://api.github.com{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "Ergo-Bounties-contested-bounties",
+            },
+        )
+        with urlopen(req, timeout=self.timeout) as response:
+            return json.loads(response.read().decode())
+
+    def timeline(self, owner: str, repo: str, number: int) -> list[Any]:
+        """All timeline events for one issue, following pagination.
+
+        Raises RateLimited (stop everything) or IssueUnavailable (skip this one).
+        A 403 is only a rate limit when GitHub says so in the headers: it is
+        also what an org's third-party-application restrictions, a SAML
+        requirement, an IP allowlist, or a disabled repository return. Treating
+        those as a rate limit would stop the sweep at the first such repo, on
+        every run, and leave the rest of the board permanently unchecked.
+        """
+        events: list[Any] = []
+        for page in range(1, MAX_TIMELINE_PAGES + 1):
+            path = f"/repos/{owner}/{repo}/issues/{number}/timeline?per_page=100&page={page}"
+            try:
+                chunk = self._get(path)
+            except HTTPError as exc:
+                if exc.code == 429 or (exc.code == 403 and _is_rate_limited(exc)):
+                    raise RateLimited(f"HTTP {exc.code} on {owner}/{repo}#{number}") from exc
+                raise IssueUnavailable(f"HTTP {exc.code} on {owner}/{repo}#{number}") from exc
+            except (URLError, TimeoutError, OSError, json.JSONDecodeError, ValueError) as exc:
+                # DNS, TLS, reset connections, read timeouts, truncated bodies.
+                # One flaky request must not discard a sweep already 80 issues deep.
+                raise IssueUnavailable(f"{type(exc).__name__} on {owner}/{repo}#{number}: {exc}") from exc
+            if not isinstance(chunk, list):
+                raise IssueUnavailable(f"unexpected timeline payload for {owner}/{repo}#{number}")
+            events.extend(chunk)
+            if len(chunk) < 100:
+                break
+        return events
+
+
+def _is_rate_limited(exc: HTTPError) -> bool:
+    headers = getattr(exc, "headers", None) or {}
+    if headers.get("Retry-After"):
+        return True
+    remaining = headers.get("X-RateLimit-Remaining")
+    return remaining is not None and str(remaining).strip() == "0"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Flag bounty issues with stalled, unmerged pull requests")
+    parser.add_argument("--input", default="data/all.md", help="Bounty listing to scan")
+    parser.add_argument("--write-dashboard", default="data/contested-bounties.md")
+    parser.add_argument("--write-json", default="data/contested_bounties.json")
+    parser.add_argument("--min-open-prs", type=int, default=2, help="Open, unmerged PRs needed to flag an issue")
+    parser.add_argument(
+        "--merge-window-days",
+        type=int,
+        default=180,
+        help="A merged PR only clears an issue if it merged within this many days",
+    )
+    parser.add_argument("--sleep", type=float, default=0.15, help="Delay between API calls (secondary rate limit)")
+    parser.add_argument("--limit", type=int, default=0, help="Only sweep the first N issues (0 = no limit)")
+    parser.add_argument("--exit-zero", action="store_true", help="Exit 0 even when contested bounties are found")
+    return parser.parse_args(argv)
+
+
+def md_text(value: object) -> str:
+    """Escape user-controlled text (issue/PR titles, usernames) for markdown output."""
+    return (
+        str(value)
+        .replace("\r", " ")
+        .replace("\n", " ")
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+    )
+
+
+def parse_bounty_rows(all_md_text: str) -> tuple[list[dict[str, Any]], int]:
+    """Extract every sweepable bounty from data/all.md.
+
+    Returns (rows, table_row_count). The second value is how many bounty rows
+    the table had at all, so the caller can notice a parser regression: rows
+    silently dropping to a handful would otherwise produce a confident,
+    nearly-empty "nothing contested" report.
+    """
+    rows: list[dict[str, Any]] = []
+    table_rows = 0
+    for line in all_md_text.splitlines():
+        if not line.startswith("| ["):
+            continue
+        table_rows += 1
+        cells = [c.strip() for c in line.strip().strip("|").split(" | ")]
+        if len(cells) < 3:
+            continue
+        cell_match = BOUNTY_CELL_RE.match(cells[1])
+        if not cell_match:
+            continue
+        repo_url, rest = cell_match.group(2), cell_match.group(5)
+        title_match = TITLE_LINK_RE.match(rest)
+        title, url = (title_match.group(1), title_match.group(2)) if title_match else (rest, repo_url)
+        issue_match = ISSUE_URL_RE.match(url)
+        if not issue_match:
+            # Reward programs and bounties posted directly on a pull request
+            # have no issue timeline to sweep. Not an error.
+            continue
+        owner, repo, number = issue_match.groups()
+        rows.append({
+            "owner": owner,
+            "repo": repo,
+            "number": int(number),
+            "title": title,
+            "url": url,
+            "value": cells[2],
+        })
+    return rows, table_rows
+
+
+def prs_from_timeline(events: list[Any]) -> list[dict[str, Any]]:
+    """Pure parser: raw `.../timeline` JSON -> deduped, sorted linked-PR records.
+
+    Kept separate from the network call so it can be tested against fixtures.
+    Everything is read defensively: GitHub returns stripped-down `source`
+    payloads for cross-references originating in repos the token cannot see,
+    and one KeyError here would abort the whole sweep.
+    """
+    by_key: dict[tuple[str, int], dict[str, Any]] = {}
+    for event in events if isinstance(events, list) else []:
+        if not isinstance(event, dict) or event.get("event") != "cross-referenced":
+            continue
+        source = (event.get("source") or {}).get("issue")
+        if not isinstance(source, dict):
+            continue
+        pull_request = source.get("pull_request")
+        if not isinstance(pull_request, dict):
+            continue
+        number = source.get("number")
+        if not isinstance(number, int):
+            continue
+        url = source.get("html_url") or ""
+        # Cross-references arrive from arbitrary repositories, and PR numbers
+        # restart at 1 in every fork. Deduping on the number alone would
+        # collapse two distinct open PRs into one and under-count contention.
+        repo_match = re.match(r"^https://github\.com/([^/]+/[^/]+)/pull/\d+$", url)
+        repo_key = repo_match.group(1) if repo_match else "?"
+        merged_at = pull_request.get("merged_at")
+        state = "open" if source.get("state") == "open" else ("merged" if merged_at else "closed")
+        by_key[(repo_key, number)] = {
+            "number": number,
+            "repo": repo_key,
+            "state": state,
+            "author": ((source.get("user") or {}).get("login")),
+            "url": url,
+            "merged_at": (merged_at or "")[:10] or None,
+        }
+    return sorted(by_key.values(), key=lambda pr: (pr["repo"], pr["number"]))
+
+
+def summarize(prs: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "open": sum(1 for pr in prs if pr["state"] == "open"),
+        "merged": sum(1 for pr in prs if pr["state"] == "merged"),
+        "closed": sum(1 for pr in prs if pr["state"] == "closed"),
+    }
+
+
+def recent_merge(prs: list[dict[str, Any]], today: dt.date, window_days: int) -> str | None:
+    """The most recent merge date within the window, if any.
+
+    `cross-referenced` records mentions, not fixes. A pull request merged years
+    ago that merely said "related to #123" should not immunise a bounty against
+    ever being flagged again -- and since cross-references accumulate over an
+    issue's whole life, the oldest bounties would be the most immunised, which
+    is exactly backwards.
+    """
+    best: str | None = None
+    for pr in prs:
+        if pr["state"] != "merged" or not pr.get("merged_at"):
+            continue
+        try:
+            merged_on = dt.date.fromisoformat(pr["merged_at"])
+        except ValueError:
+            continue
+        if (today - merged_on).days <= window_days and (best is None or pr["merged_at"] > best):
+            best = pr["merged_at"]
+    return best
+
+
+def is_contested(record: dict[str, Any], min_open_prs: int) -> bool:
+    return record.get("open", 0) >= min_open_prs and not record.get("recent_merge")
+
+
+def sweep(
+    client: Any,
+    rows: list[dict[str, Any]],
+    min_open_prs: int,
+    merge_window_days: int,
+    sleep_s: float,
+    limit: int,
+    today: dt.date,
+) -> dict[str, Any]:
+    targets = rows[:limit] if limit > 0 else rows
+    attempted = len(targets)
+    items: dict[str, Any] = {}
+    done = 0
+    failed = 0
+    consecutive_failures = 0
+    stopped = False
+
+    for row in targets:
+        try:
+            events = client.timeline(row["owner"], row["repo"], row["number"])
+        except RateLimited as exc:
+            print(f"contested-bounties: {exc}, stopping sweep early", file=sys.stderr)
+            stopped = True
+            break
+        except IssueUnavailable as exc:
+            failed += 1
+            consecutive_failures += 1
+            print(f"contested-bounties: skipping {row['url']}: {exc}", file=sys.stderr)
+            # Back off on the failure path too. A burst of unthrottled retries
+            # is itself a way to trip GitHub's secondary rate limit.
+            time.sleep(sleep_s)
+            if consecutive_failures >= 8:
+                print(
+                    f"contested-bounties: {consecutive_failures} consecutive failures, aborting sweep",
+                    file=sys.stderr,
+                )
+                stopped = True
+                break
+            continue
+
+        consecutive_failures = 0
+        prs = prs_from_timeline(events)
+        record = {**row, **summarize(prs), "checked": today.isoformat()}
+        merged_recently = recent_merge(prs, today, merge_window_days)
+        if merged_recently:
+            record["recent_merge"] = merged_recently
+        if prs:
+            record["prs"] = prs[-10:]
+        items[row["url"]] = record
+        done += 1
+        time.sleep(sleep_s)
+
+    return {
+        "items": items,
+        "swept": done,
+        "attempted": attempted,
+        "failed": failed,
+        # A limit truncates the sweep as surely as a rate limit does; a report
+        # covering 5 of 97 bounties must not read as a complete board.
+        "partial": stopped or done < attempted or (limit > 0 and limit < len(rows)),
+    }
+
+
+def merge_with_previous(
+    fresh_items: dict[str, Any],
+    previous: dict[str, Any] | None,
+    live_urls: set[str],
+) -> tuple[dict[str, Any], int]:
+    """Carry forward previous findings for issues this run did not reach.
+
+    Without this, one rate-limited morning replaces a report full of known
+    traps with whatever handful of issues got through. Entries whose bounty has
+    since left the board are dropped rather than haunting the report forever.
+    """
+    merged = dict(fresh_items)
+    carried = 0
+    previous_items = (previous or {}).get("items") or {}
+    fallback_date = (previous or {}).get("fetched")
+    for url, record in previous_items.items():
+        if url in merged or url not in live_urls or not isinstance(record, dict):
+            continue
+        carried_record = dict(record)
+        carried_record.setdefault("checked", fallback_date)
+        merged[url] = carried_record
+        carried += 1
+    return merged, carried
+
+
+def build_result(
+    swept: dict[str, Any],
+    previous: dict[str, Any] | None,
+    rows: list[dict[str, Any]],
+    min_open_prs: int,
+    merge_window_days: int,
+    today: dt.date,
+) -> dict[str, Any]:
+    live_urls = {row["url"] for row in rows}
+    items, carried = merge_with_previous(swept["items"], previous, live_urls)
+    contested = sorted(
+        (rec for rec in items.values() if is_contested(rec, min_open_prs)),
+        key=lambda rec: (rec.get("open", 0), rec.get("number", 0)),
+        reverse=True,
+    )
+    return {
+        "fetched": today.isoformat(),
+        "min_open_prs": min_open_prs,
+        "merge_window_days": merge_window_days,
+        "items": items,
+        "contested": [rec["url"] for rec in contested],
+        "swept": swept["swept"],
+        "attempted": swept["attempted"],
+        "failed": swept["failed"],
+        "carried": carried,
+        "partial": swept["partial"],
+    }
+
+
+def render_dashboard(result: dict[str, Any]) -> str:
+    contested = [result["items"][url] for url in result["contested"] if url in result["items"]]
+    today = result["fetched"]
+
+    status = f"Swept {result['swept']}/{result['attempted']} open bounty issues this run"
+    details = [f"{result.get('failed', 0)} failed"]
+    if result.get("carried"):
+        details.append(f"{result['carried']} carried over from a previous run")
+    status += f" ({', '.join(details)})."
+    if result.get("partial"):
+        status += " Partial sweep -- the rest of the board was not checked this run."
+
+    lines = [
+        MARKER,
+        "# Contested Bounties",
+        "",
+        f"Generated: {today}",
+        status,
+        "",
+        (
+            "Some bounties attract pull request after pull request and never merge any of them, "
+            "so the issue stays open and keeps looking available. This report flags open bounty "
+            f"issues with {result['min_open_prs']}+ open pull requests and no pull request merged "
+            f"in the last {result.get('merge_window_days', 180)} days, so you can see the queue "
+            "before adding to it."
+        ),
+        "",
+    ]
+
+    if not contested:
+        lines.extend(["No contested bounties among the issues checked so far.", ""])
+    else:
+        lines.append(f"## Contested ({len(contested)})")
+        lines.append("")
+        for rec in contested:
+            value = f" ({md_text(rec['value'])})" if rec.get("value") else ""
+            checked = rec.get("checked")
+            stale = "" if checked == today else f" _(checked {md_text(checked or 'unknown')})_"
+            lines.append(
+                f"- [{md_text(rec['owner'])}/{md_text(rec['repo'])}#{rec['number']}]({rec['url']}) "
+                f"{md_text(rec['title'])}{value} — {rec.get('open', 0)} open PR(s), "
+                f"{rec.get('merged', 0)} merged{stale}"
+            )
+            for pr in rec.get("prs", []):
+                author = f"@{md_text(pr['author'])}" if pr.get("author") else "unknown"
+                lines.append(f"  - [#{pr['number']}]({pr.get('url') or rec['url']}) {md_text(pr['state'])} by {author}")
+        lines.append("")
+
+    lines.extend([
+        "## Notes",
+        "",
+        (
+            "- An issue missing from `data/contested_bounties.json`'s `items` has not been checked yet, "
+            "and an issue whose `checked` date is older than this report was checked then, not now. "
+            "Neither means clear."
+        ),
+        (
+            "- A pull request that cross-references an issue is not necessarily an attempt to fix it, "
+            "so treat the queue below as a prompt to read the issue, not as a verdict."
+        ),
+        "- Read-only report: nothing here is posted back to GitHub, and no PRs or issues are touched.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def load_previous(path: str) -> dict[str, Any] | None:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("contested-bounties: no GITHUB_TOKEN/GH_TOKEN, sweep skipped", file=sys.stderr)
+        return 0
+
+    if args.limit < 0:
+        print("contested-bounties: --limit must be >= 0", file=sys.stderr)
+        return 2
+
+    try:
+        with open(args.input, "r", encoding="utf-8") as handle:
+            all_md_text = handle.read()
+    except OSError as exc:
+        print(f"contested-bounties: cannot read {args.input}: {exc}", file=sys.stderr)
+        return 2
+
+    rows, table_rows = parse_bounty_rows(all_md_text)
+    dropped = table_rows - len(rows)
+    print(f"contested-bounties: {len(rows)} sweepable issues from {table_rows} bounty rows ({dropped} without an issue URL)")
+    # Reward programs and PR-hosted bounties legitimately have no issue to
+    # sweep, but if most of the table stops parsing that is a format
+    # regression, and a near-empty "nothing contested" report would look like
+    # good news rather than a broken parser.
+    if table_rows and len(rows) < table_rows * 0.5:
+        print(
+            f"contested-bounties: only {len(rows)}/{table_rows} rows parsed, {args.input} format may have changed",
+            file=sys.stderr,
+        )
+        return 2
+
+    previous = load_previous(args.write_json)
+    today = dt.datetime.now(dt.timezone.utc).date()
+    swept = sweep(GitHub(token), rows, args.min_open_prs, args.merge_window_days, args.sleep, args.limit, today)
+
+    if swept["swept"] == 0 and swept["attempted"] > 0 and previous:
+        # Nothing at all got through. Keep the committed report rather than
+        # replacing known traps with an empty page.
+        print(
+            f"contested-bounties: swept 0/{swept['attempted']}, keeping previous report from {previous.get('fetched')}",
+            file=sys.stderr,
+        )
+        return 0 if args.exit_zero else 1
+
+    result = build_result(swept, previous, rows, args.min_open_prs, args.merge_window_days, today)
+    contested_count = len(result["contested"])
+    print(
+        f"contested-bounties: swept {result['swept']}/{result['attempted']} issues, "
+        f"{result['failed']} failed, {result['carried']} carried over; "
+        f"{contested_count} contested{' (partial sweep)' if result['partial'] else ''}"
+    )
+
+    if args.write_json:
+        with open(args.write_json, "w", encoding="utf-8") as handle:
+            json.dump(result, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    if args.write_dashboard:
+        with open(args.write_dashboard, "w", encoding="utf-8") as handle:
+            handle.write(render_dashboard(result))
+
+    if args.exit_zero:
+        return 0
+    return 1 if contested_count else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tests/test_detect_contested_bounties.py
+++ b/src/tests/test_detect_contested_bounties.py
@@ -1,0 +1,345 @@
+import datetime as dt
+
+import pytest
+
+from scripts.detect_contested_bounties import (
+    GitHub,
+    IssueUnavailable,
+    RateLimited,
+    build_result,
+    is_contested,
+    md_text,
+    merge_with_previous,
+    parse_bounty_rows,
+    prs_from_timeline,
+    recent_merge,
+    render_dashboard,
+    summarize,
+    sweep,
+)
+
+TODAY = dt.date(2026, 8, 11)
+
+SAMPLE_ROW = (
+    "| [ergoplatform](by_org/ergoplatform.md) | "
+    "[sigmastate-interpreter](https://github.com/ergoplatform/sigmastate-interpreter)/"
+    "[Finish SigmaMap implementation](https://github.com/ergoplatform/sigmastate-interpreter/issues/1067) | "
+    "1000 SigUSD (~Σ4215) | 486d | 283d | 2 | [Scala](by_language/scala.md) | [Reserve](#) |"
+)
+HEADER = "|Organisation|Bounty|Value|Age|Updated|Comments|Primary Language|Reserve|\n|---|---|---|---|---|---|---|---|\n"
+
+
+def xref(number, state, *, merged_at=None, repo="o/r", author="alice", is_pr=True):
+    source = {"number": number, "state": state, "user": {"login": author}, "html_url": f"https://github.com/{repo}/pull/{number}"}
+    if is_pr:
+        source["pull_request"] = {"merged_at": merged_at}
+    return {"event": "cross-referenced", "source": {"issue": source}}
+
+
+def row(url="https://github.com/o/r/issues/1", number=1, title="Trap issue"):
+    return {"owner": "o", "repo": "r", "number": number, "title": title, "url": url, "value": "500 ERG"}
+
+
+class FakeClient:
+    """Stands in for GitHub. Each entry is either an event list or an exception to raise."""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def timeline(self, owner, repo, number):
+        self.calls.append((owner, repo, number))
+        result = self.responses.get(number, [])
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+# --- row parsing -------------------------------------------------------------
+
+def test_parse_bounty_rows_extracts_owner_repo_number_title():
+    rows, table_rows = parse_bounty_rows(HEADER + SAMPLE_ROW + "\n")
+
+    assert table_rows == 1
+    assert rows == [{
+        "owner": "ergoplatform",
+        "repo": "sigmastate-interpreter",
+        "number": 1067,
+        "title": "Finish SigmaMap implementation",
+        "url": "https://github.com/ergoplatform/sigmastate-interpreter/issues/1067",
+        "value": "1000 SigUSD (~Σ4215)",
+    }]
+
+
+def test_parse_bounty_rows_counts_unsweepable_rows_separately():
+    """PR-hosted bounties have no issue timeline, but must still count as table rows.
+
+    The caller uses the ratio to detect a format regression; if unsweepable
+    rows vanished from the denominator, a broken parser would look healthy.
+    """
+    pr_row = (
+        "| [ergoplatform](by_org/ergoplatform.md) | "
+        "[ergo](https://github.com/ergoplatform/ergo)/"
+        "[Some work](https://github.com/ergoplatform/ergo/pull/2249) | "
+        "10 ERG | 5d | 5d | 0 | [Scala](by_language/scala.md) | [Reserve](#) |"
+    )
+    rows, table_rows = parse_bounty_rows(HEADER + SAMPLE_ROW + "\n" + pr_row + "\n")
+
+    assert len(rows) == 1
+    assert table_rows == 2
+
+
+def test_parse_bounty_rows_ignores_prose_and_malformed_rows():
+    text = "# All Open Bounties\n\nSome prose.\n" + HEADER + "| [no bounty cell] | one |\n"
+    rows, table_rows = parse_bounty_rows(text)
+    assert rows == []
+    assert table_rows == 1
+
+
+# --- timeline parsing --------------------------------------------------------
+
+def test_prs_from_timeline_classifies_open_merged_closed():
+    events = [
+        {"event": "commented"},
+        xref(1, "open"),
+        xref(2, "closed", merged_at="2026-01-01T00:00:00Z", author="bob"),
+        xref(3, "closed", author="carol"),
+        xref(4, "open", is_pr=False),  # a plain issue cross-reference, not a PR
+    ]
+
+    prs = prs_from_timeline(events)
+
+    assert [(pr["number"], pr["state"]) for pr in prs] == [(1, "open"), (2, "merged"), (3, "closed")]
+    assert summarize(prs) == {"open": 1, "merged": 1, "closed": 1}
+
+
+def test_prs_from_timeline_keys_on_repo_and_number():
+    """Two open PRs numbered 12 in different repos are two PRs, not one.
+
+    PR numbers restart at 1 in every fork, so deduping on the number alone
+    under-counts contention and can un-flag a genuinely contested issue.
+    """
+    prs = prs_from_timeline([xref(12, "open", repo="a/one"), xref(12, "open", repo="b/two")])
+
+    assert summarize(prs)["open"] == 2
+
+
+def test_prs_from_timeline_dedupes_repeated_events_for_one_pr():
+    prs = prs_from_timeline([
+        xref(5, "open", repo="o/r"),
+        xref(5, "closed", merged_at="2026-02-02T00:00:00Z", repo="o/r"),
+    ])
+
+    assert len(prs) == 1
+    assert prs[0]["state"] == "merged"
+
+
+@pytest.mark.parametrize("events", [
+    [],
+    None,
+    ["not-a-dict"],
+    [{"event": "cross-referenced", "source": None}],
+    [{"event": "cross-referenced", "source": {"issue": {"pull_request": {}}}}],           # no number
+    [{"event": "cross-referenced", "source": {"issue": {"number": 1, "pull_request": None}}}],
+    [{"event": "cross-referenced", "source": {"issue": {"number": "x", "pull_request": {}}}}],
+])
+def test_prs_from_timeline_tolerates_stripped_payloads(events):
+    """GitHub returns partial `source` objects for cross-refs from invisible repos.
+
+    A KeyError here would escape the per-issue handler and abort the sweep.
+    """
+    assert prs_from_timeline(events) == []
+
+
+# --- contested classification -----------------------------------------------
+
+def test_recent_merge_only_counts_merges_inside_the_window():
+    fresh = [{"state": "merged", "merged_at": "2026-07-01"}]
+    ancient = [{"state": "merged", "merged_at": "2020-01-01"}]
+
+    assert recent_merge(fresh, TODAY, 180) == "2026-07-01"
+    assert recent_merge(ancient, TODAY, 180) is None
+    assert recent_merge([{"state": "open", "merged_at": None}], TODAY, 180) is None
+
+
+def test_is_contested_requires_open_threshold_and_no_recent_merge():
+    assert is_contested({"open": 2}, min_open_prs=2) is True
+    assert is_contested({"open": 1}, min_open_prs=2) is False
+    assert is_contested({"open": 3, "recent_merge": "2026-07-01"}, min_open_prs=2) is False
+    # An ancient merged mention must not immunise the issue forever.
+    assert is_contested({"open": 3, "merged": 1}, min_open_prs=2) is True
+
+
+def test_md_text_escapes_markdown_control_characters():
+    assert md_text("bad | [title]\nnext") == "bad \\| \\[title\\] next"
+
+
+# --- sweep behaviour ---------------------------------------------------------
+
+def test_sweep_records_checked_date_and_flags_contested():
+    client = FakeClient({1: [xref(10, "open"), xref(11, "open", repo="o/r2")]})
+
+    result = sweep(client, [row()], min_open_prs=2, merge_window_days=180, sleep_s=0, limit=0, today=TODAY)
+
+    record = result["items"]["https://github.com/o/r/issues/1"]
+    assert record["open"] == 2
+    assert record["checked"] == "2026-08-11"
+    assert result["partial"] is False
+
+
+def test_sweep_skips_one_unavailable_issue_and_keeps_the_rest():
+    """A single 404/permission failure must not cost the whole sweep."""
+    client = FakeClient({1: IssueUnavailable("HTTP 404"), 2: [xref(10, "open")]})
+    rows = [row(url="u1", number=1), row(url="u2", number=2)]
+
+    result = sweep(client, rows, min_open_prs=2, merge_window_days=180, sleep_s=0, limit=0, today=TODAY)
+
+    assert result["swept"] == 1
+    assert result["failed"] == 1
+    assert "u2" in result["items"] and "u1" not in result["items"]
+    assert result["partial"] is True
+
+
+def test_sweep_stops_on_rate_limit_and_keeps_what_it_has():
+    client = FakeClient({1: [xref(10, "open")], 2: RateLimited("HTTP 429"), 3: [xref(11, "open")]})
+    rows = [row(url="u1", number=1), row(url="u2", number=2), row(url="u3", number=3)]
+
+    result = sweep(client, rows, min_open_prs=2, merge_window_days=180, sleep_s=0, limit=0, today=TODAY)
+
+    assert result["swept"] == 1
+    assert client.calls == [("o", "r", 1), ("o", "r", 2)]  # stopped, did not try #3
+    assert result["partial"] is True
+
+
+def test_sweep_aborts_after_consecutive_failures_but_a_success_resets_the_counter():
+    rows = [row(url=f"u{i}", number=i) for i in range(1, 12)]
+    responses = {1: [xref(1, "open")]}
+    responses.update({i: IssueUnavailable("HTTP 500") for i in range(2, 12)})
+
+    result = sweep(FakeClient(responses), rows, min_open_prs=2, merge_window_days=180, sleep_s=0, limit=0, today=TODAY)
+
+    assert result["swept"] == 1
+    assert result["failed"] == 8  # aborted at 8 consecutive, not after all 10
+    assert result["partial"] is True
+
+
+def test_sweep_with_limit_reports_itself_as_partial():
+    """A --limit 1 smoke test must never publish a clean bill of health for the board."""
+    rows = [row(url=f"u{i}", number=i) for i in range(1, 4)]
+    client = FakeClient({i: [] for i in range(1, 4)})
+
+    result = sweep(client, rows, min_open_prs=2, merge_window_days=180, sleep_s=0, limit=1, today=TODAY)
+
+    assert result["swept"] == 1
+    assert result["attempted"] == 1
+    assert result["partial"] is True
+    assert len(client.calls) == 1
+
+
+# --- carry-forward and rendering --------------------------------------------
+
+def test_merge_with_previous_carries_unswept_issues_and_drops_departed_ones():
+    fresh = {"u1": {"open": 2, "checked": "2026-08-11"}}
+    previous = {"fetched": "2026-08-01", "items": {"u2": {"open": 3}, "u3": {"open": 4}}}
+
+    merged, carried = merge_with_previous(fresh, previous, live_urls={"u1", "u2"})
+
+    assert carried == 1
+    assert merged["u2"]["checked"] == "2026-08-01"  # stamped with when it was really seen
+    assert "u3" not in merged  # bounty left the board; do not haunt the report
+
+
+def test_build_result_keeps_known_traps_visible_after_a_partial_sweep():
+    """Regression guard: a rate-limited run must not empty a report full of traps."""
+    previous = {
+        "fetched": "2026-08-01",
+        "items": {f"u{i}": {"owner": "o", "repo": "r", "number": i, "title": "t", "url": f"u{i}", "open": 3, "merged": 0} for i in range(2, 12)},
+    }
+    swept = {"items": {"u1": {"owner": "o", "repo": "r", "number": 1, "title": "t", "url": "u1", "open": 2, "merged": 0, "checked": "2026-08-11"}},
+             "swept": 1, "attempted": 11, "failed": 0, "partial": True}
+    rows = [row(url=f"u{i}", number=i) for i in range(1, 12)]
+
+    result = build_result(swept, previous, rows, min_open_prs=2, merge_window_days=180, today=TODAY)
+
+    assert len(result["contested"]) == 11  # 1 fresh + 10 carried, not 1
+    assert result["carried"] == 10
+
+
+def test_render_dashboard_marks_partial_sweeps_and_stale_entries():
+    result = {
+        "fetched": "2026-08-11", "min_open_prs": 2, "merge_window_days": 180,
+        "items": {
+            "https://github.com/o/r/issues/1": {
+                "owner": "o", "repo": "r", "number": 1, "title": "Trap issue",
+                "url": "https://github.com/o/r/issues/1", "value": "500 ERG",
+                "open": 2, "merged": 0, "checked": "2026-08-01",
+                "prs": [{"number": 10, "state": "open", "author": "alice", "url": "https://github.com/o/r/pull/10"}],
+            },
+        },
+        "contested": ["https://github.com/o/r/issues/1"],
+        "swept": 1, "attempted": 5, "failed": 1, "carried": 1, "partial": True,
+    }
+
+    out = render_dashboard(result)
+
+    assert "o/r#1" in out and "Trap issue" in out and "@alice" in out
+    assert "2 open PR(s), 0 merged" in out
+    assert "Partial sweep" in out
+    assert "carried over from a previous run" in out
+    assert "_(checked 2026-08-01)_" in out
+    assert "has not been checked yet" in out
+
+
+def test_render_dashboard_never_claims_a_clean_board():
+    result = {"fetched": "2026-08-11", "min_open_prs": 2, "merge_window_days": 180, "items": {},
+              "contested": [], "swept": 5, "attempted": 5, "failed": 0, "carried": 0, "partial": False}
+
+    out = render_dashboard(result)
+
+    assert "among the issues checked so far" in out
+
+
+# --- rate-limit classification ----------------------------------------------
+
+@pytest.mark.parametrize("code,headers,expected", [
+    (429, {}, RateLimited),
+    (403, {"X-RateLimit-Remaining": "0"}, RateLimited),
+    (403, {"Retry-After": "60"}, RateLimited),
+    # A permission 403 (org app restrictions, SAML, IP allowlist) is one bad
+    # repo, not a reason to abandon the board on every future run.
+    (403, {"X-RateLimit-Remaining": "4999"}, IssueUnavailable),
+    (403, {}, IssueUnavailable),
+    (404, {}, IssueUnavailable),
+    (410, {}, IssueUnavailable),
+])
+def test_timeline_distinguishes_rate_limits_from_per_repo_failures(monkeypatch, code, headers, expected):
+    from urllib.error import HTTPError
+
+    def boom(*_args, **_kwargs):
+        raise HTTPError("https://api.github.com", code, "nope", headers, None)
+
+    monkeypatch.setattr("scripts.detect_contested_bounties.urlopen", boom)
+
+    with pytest.raises(expected):
+        GitHub("token").timeline("o", "r", 1)
+
+
+def test_timeline_follows_pagination_so_busy_issues_are_not_truncated():
+    """Timeline events come back oldest-first.
+
+    Reading only page 1 of a very active issue would drop the most recent
+    cross-references -- on exactly the issues most likely to be contested.
+    """
+    pages = {1: [{"event": "commented"}] * 100, 2: [xref(7, "open"), xref(8, "open")]}
+    calls = []
+
+    class PagedGitHub(GitHub):
+        def _get(self, path):
+            calls.append(path)
+            page = int(path.rsplit("page=", 1)[1])
+            return pages.get(page, [])
+
+    events = PagedGitHub("token").timeline("o", "r", 1)
+
+    assert len(calls) == 2
+    assert summarize(prs_from_timeline(events))["open"] == 2


### PR DESCRIPTION
Some bounties look ideal from the listing alone — clear scope, fair reward — and are traps anyway: contributor after contributor opens a pull request, none of them is ever merged, and the issue stays open forever because nothing ever closes it. Comment count doesn't catch this; linked pull requests do.

This adds a daily, read-only sweep that reads every open bounty from `data/all.md`, walks each issue's GitHub timeline for cross-referenced pull requests, and flags issues with 2+ open PRs and no merge in the last 180 days as **contested**.

**Added:**
- `scripts/detect_contested_bounties.py` — stdlib-only (`urllib`), same style as `scripts/triage_submission_prs.py`. Never comments, labels, or closes anything — pure read + report.
- `.github/workflows/detect-contested-bounties.yml` — runs at 01:15 UTC, after the daily bounty update has committed `data/all.md`. Commits `data/contested-bounties.md` and `data/contested_bounties.json` only when they change.
- `src/tests/test_detect_contested_bounties.py` — 33 tests over parsing, classification, sweep control and rendering, using a fake client so no HTTP mocking is needed.
- Doc updates: `docs/how-it-works.md` (new section + schedule/output entries), `README.md` (one link alongside the other discovery pages), `AGENTS.md` (one line under Useful Commands).

### The design is mostly about being honest when the sweep goes wrong

A report that quietly under-reports traps is worse than no report at all, so most of the complexity here is failure handling:

- **The timeline is paginated.** Events come back oldest-first, so reading only page 1 would drop the most recent cross-references — precisely on the busiest issues, which are the ones most likely to be contested. The failure mode would have been anti-correlated with the tool's purpose.
- **A merge only clears an issue if it's recent** (`--merge-window-days`, default 180). `cross-referenced` records a *mention*, not a fix; without a recency limit one PR merged years ago saying "related to #123" would immunise that bounty forever, and since cross-references accumulate over an issue's whole life, the oldest bounties would be the most immunised.
- **Every record carries its own `checked` date.** Missing from `items` means never checked; an older `checked` date means checked then, not now. Neither is "clear", and the dashboard says so instead of implying a clean bill of health.
- **A cut-short run carries forward** findings for issues it didn't reach, shown with the date they were really observed, rather than replacing a report full of known traps with the handful that got through. Carried entries are dropped once their bounty leaves the board, so the report can't accumulate ghosts.
- **A 403 is only a rate limit when the headers say so.** An org's third-party-application restrictions, a SAML requirement or a disabled repo is one skipped issue — not a reason to abandon the rest of the board on every future run.
- PRs are deduped on `(repo, number)`, since numbers restart at 1 in every fork and collapsing two distinct open PRs would under-count contention.
- Network errors, truncated bodies and stripped-down API payloads are handled per-issue, so one flaky request can't discard a sweep already 80 issues deep.

### Verification

`./test.sh` (compileall, config/workflow JSON+YAML validation, `run_bounty_check`, 68 pytest tests, `git diff --check`) and `ruff check` against `.trunk/configs/ruff.toml` both pass — confirmed on a pristine clone of `main` with this patch applied, not just in my working tree.

Row parsing was checked against the real `data/all.md`: 97 of 106 rows are sweepable, and I confirmed the 9 dropped rows individually — 6 bounties hosted on pull requests and 3 reward-program rows, none of which has an issue timeline to read. The script logs that split on every run and bails out if more than half the table stops parsing, so a future change to the generator's cell format can't silently degrade into a confident, nearly-empty report.

An offline end-to-end run over all 97 real rows with a faked client confirms the honesty properties above: a rate-limited second run keeps all 22 findings from the first (marked with their real observation date) and declares itself partial, and a total-failure run leaves the committed report byte-identical.

**Not verified: the live sweep.** I had no GitHub API access in the environment I built this in, so the Timeline API responses are fixtures shaped to the documented v2022-11-28 schema (`cross-referenced` events, `source.issue.pull_request.merged_at`) rather than recorded traffic. Worth a `workflow_dispatch` run with `limit: 20` as a first check before trusting the daily job — that path is explicitly marked partial in the output, so it can't publish a whole-board all-clear from a 20-issue sample.
