### PR TITLE
Create ergoplatform-ergo-2185.json (reservation, 1 g GOLD)

### DIFF
--- a/submissions/ergoplatform-ergo-2185.json
+++ b/submissions/ergoplatform-ergo-2185.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2462",
+  "work_title": "Put mining fee inputs into multiple transactions when too many of them",
+  "bounty_id": "ergoplatform/ergo#2185",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/2185",
+  "payment_currency": "g GOLD",
+  "bounty_value": 1.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-11",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2462 (open, awaiting review).",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for ergoplatform/ergo#2185 (Put mining fee inputs into multiple transactions when too many of them).

Work is implemented and submitted upstream as ergoplatform/ergo#2462, which is open and awaiting review. Status stays `in-progress` until that PR is merged.

Note for whoever triages this: PR ergoplatform/ergo#2186, which is merged, only added a test - `CandidateGenerator.collectRewards` on current master still builds a single fee-collecting transaction with every fee box as an input, so the issue itself was still open work.