### PR TITLE
Create ergoplatform-ergo-1154.json (reservation, 1000 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-1154.json
+++ b/submissions/ergoplatform-ergo-1154.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2466",
+  "work_title": "Unconfirmed wallet transactions during node restart",
+  "bounty_id": "ergoplatform/ergo#1154",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1154",
+  "payment_currency": "SigUSD",
+  "bounty_value": 1000.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-13",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2466 (open, awaiting review). Wallet-related unconfirmed transactions are kept in WalletStorage, replayed into the off-chain registry when the wallet loads, and put back into the memory pool at start-up.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for [ergoplatform/ergo#1154](https://github.com/ergoplatform/ergo/issues/1154), "Unconfirmed wallet transactions during node restart" (B-1000 SigUSD).

Work is implemented and submitted upstream as [ergoplatform/ergo#2466](https://github.com/ergoplatform/ergo/pull/2466) (10 files, +496/-10, full test suite green). Status is `in-progress` because that pull request is still open; I will move it to `awaiting-review` once it is merged.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work (not yet - upstream PR is open)
- [ ] Paid claims include `payment_tx_id` and `payment_date` (not applicable)

## Notes

The issue is not assigned and has no other pull request or reservation against it.