### PR TITLE
Create ergoplatform-ergo-1392.json (reservation, 1000 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-1392.json
+++ b/submissions/ergoplatform-ergo-1392.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2467",
+  "work_title": "Sign a custom message [Feature request]",
+  "bounty_id": "ergoplatform/ergo#1392",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1392",
+  "payment_currency": "SigUSD",
+  "bounty_value": 1000.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-13",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2467 (open, awaiting review). Adds POST /wallet/signMessage and POST /utils/verifyMessage, using the sigma protocol the node already uses for transaction proofs, with EIP-0028 style message wrapping so a message signature can not be turned into a transaction proof.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for [ergoplatform/ergo#1392](https://github.com/ergoplatform/ergo/issues/1392), "Sign a custom message" (B-1000 SigUSD).

Work is implemented and submitted upstream as [ergoplatform/ergo#2467](https://github.com/ergoplatform/ergo/pull/2467) (13 files, +584/-7). Status is `in-progress` because that pull request is still open; I will move it to `awaiting-review` once it is merged.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work (not yet - upstream PR is open)
- [ ] Paid claims include `payment_tx_id` and `payment_date` (not applicable)

## Notes

The issue is unassigned and had no pull request or reservation against it, open since June 2021.