### PR TITLE
Add submission for bounty ID ergoplatform/explorer-backend#258

### DIFF
--- a/submissions/ergoplatform-explorer-backend-258.json
+++ b/submissions/ergoplatform-explorer-backend-258.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/explorer-backend/pull/287",
+  "work_title": "Incompatible doc",
+  "bounty_id": "ergoplatform/explorer-backend#258",
+  "original_issue_link": "https://github.com/ergoplatform/explorer-backend/issues/258",
+  "payment_currency": "ERG",
+  "bounty_value": 100.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-13",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/explorer-backend/pull/287 (open, awaiting review). The v1 API documents additionalRegisters as a plain string per register while it returns an object; the eight v1 response models now describe the expanded form, with a test on the generated OpenAPI document.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for [ergoplatform/explorer-backend#258](https://github.com/ergoplatform/explorer-backend/issues/258) — "Incompatible doc".

The work is already implemented and submitted upstream: **https://github.com/ergoplatform/explorer-backend/pull/287** (open, awaiting review).

The v1 API documents `additionalRegisters` as a plain string per register, while it actually returns an object (`serializedValue` / `sigmaType` / `renderedValue`). That string shape is what **v0** returns, since `registers.convolveJson` flattens each register there; v1 hands the expanded form through untouched. Clients generated from the v1 document therefore did not match the responses. The eight v1 response models now share a single `RegisterInfo` schema, and a test asserts on the generated OpenAPI document so the two cannot drift apart again.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — upstream PR is open, not merged yet; status is `in-progress`
- [ ] Paid claims include `payment_tx_id` and `payment_date` — not applicable yet

## Notes

Status will be moved to `awaiting-review` once explorer-backend#287 is merged.
