### PR TITLE
Add submission for bounty ID BetterMoneyLabs/chaincash-rs#58

### DIFF
--- a/submissions/bettermoneylabs-chaincash-rs-58.json
+++ b/submissions/bettermoneylabs-chaincash-rs-58.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/BetterMoneyLabs/chaincash-rs/pull/64",
+  "work_title": "Support refunds",
+  "bounty_id": "BetterMoneyLabs/chaincash-rs#58",
+  "original_issue_link": "https://github.com/BetterMoneyLabs/chaincash-rs/issues/58",
+  "payment_currency": "g GOLD",
+  "bounty_value": 2.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-13",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/BetterMoneyLabs/chaincash-rs/pull/64 (open, awaiting review). Refunds end to end: an API to announce one, automatic completion once the timelock expires, and an API to list past and current refunds with their statuses. 18 files, 12 new tests, the offchain ones signed against the real reserve contract.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Reservation for [BetterMoneyLabs/chaincash-rs#58](https://github.com/BetterMoneyLabs/chaincash-rs/issues/58) — "Support refunds" (2 g GOLD).

The work is already implemented and submitted upstream: **https://github.com/BetterMoneyLabs/chaincash-rs/pull/64** (open, awaiting review).

Refunds end to end, which is the three things the issue asks for: an API to announce one, automatic completion once the timelock expires, and an API to list past and current refunds with their statuses. The reserve contract already had the `init refund` / `cancel refund` / `complete refund` actions and nothing offchain used them. 18 files, 12 new tests; the offchain ones build each transaction and then sign it against the real reserve contract, so the interpreter validates the context extension, the registers and the timelock rather than my reading of the contract.

Along the way it also fixes `ReserveBoxSpec` reading R5 as a `Long` where the contract declares it `Int` — every reserve with a pending refund failed to parse, which silently dropped it from the scanner and from `/reserves/wallet`.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — upstream PR is open, not merged yet; status is `in-progress`
- [ ] Paid claims include `payment_tx_id` and `payment_date` — not applicable yet

## Notes

Status will be moved to `awaiting-review` once chaincash-rs#64 is merged.
