### PR TITLE
[WIP] Bounty ergoplatform/ergo-wallet-app#186 - Retry signed transaction broadcast

### DIFF
--- a/submissions/electronicutility-ergo-wallet-app-186.json
+++ b/submissions/electronicutility-ergo-wallet-app-186.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "ElectronicUtility",
+  "wallet_address": "9hPwNfbkE4MDBvnPSDfKZBrkB9eTrViSjPrA12sq8gh3R9odJKt",
+  "contact_method": "GitHub: @ElectronicUtility",
+  "work_link": "",
+  "work_title": "Retry signed transaction broadcast across known nodes",
+  "bounty_id": "ergoplatform/ergo-wallet-app#186",
+  "original_issue_link": "https://github.com/ergoplatform/ergo-wallet-app/issues/186",
+  "payment_currency": "ERG",
+  "bounty_value": 300,
+  "status": "in-progress",
+  "submission_date": "",
+  "expected_completion": "2026-08-18",
+  "description": "Broadcast the same already-signed transaction to an ordered, de-duplicated sequence of the preferred node followed by known nodes, stop on the first valid transaction ID, preserve useful failure information, and add focused JVM tests.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}

--- a/submissions/electronicutility-ergo-wallet-app-186.json
+++ b/submissions/electronicutility-ergo-wallet-app-186.json
@@ -10,7 +10,7 @@
   "bounty_value": 300,
   "status": "in-progress",
   "submission_date": "2026-08-14",
-  "expected_completion": "2026-08-18",
+  "expected_completion": "2026-09-03",
   "description": "Broadcast the same already-signed transaction to an ordered, de-duplicated sequence of the preferred node followed by known nodes, stop on the first valid transaction ID, preserve useful failure information, and add focused JVM tests.",
   "review_notes": "",
   "payment_tx_id": "",

--- a/submissions/electronicutility-ergo-wallet-app-186.json
+++ b/submissions/electronicutility-ergo-wallet-app-186.json
@@ -9,7 +9,7 @@
   "payment_currency": "ERG",
   "bounty_value": 300,
   "status": "in-progress",
-  "submission_date": "",
+  "submission_date": "2026-08-14",
   "expected_completion": "2026-08-18",
   "description": "Broadcast the same already-signed transaction to an ordered, de-duplicated sequence of the preferred node followed by known nodes, stop on the first valid transaction ID, preserve useful failure information, and add focused JVM tests.",
   "review_notes": "",


### PR DESCRIPTION
## Reservation

Reserves `ergoplatform/ergo-wallet-app#186` for implementation by `@ElectronicUtility`.

Planned scope:

- sign the transaction exactly once;
- broadcast the same signed transaction to the preferred node and then the de-duplicated known-node list;
- stop on the first valid transaction ID;
- preserve useful failure information if every node fails;
- add focused JVM tests for ordering, fallback, de-duplication, early success, and all-node failure.

Expected completion: 2026-08-18.

Implementation progress: https://github.com/ergoplatform/ergo-wallet-app/pull/218 is open and locally verified with the full `common-jvm` test suite.

No bounty reward is being claimed at this stage. `work_link` remains empty until the upstream implementation is merged. `submission_date` records the reservation submission date because the repository triage bot requires a non-placeholder value for every status.
