### PR TITLE
Create stabilitynexus-benefactionplatform-ergo-78.json (completed, 1000 BENE)

### DIFF
--- a/submissions/stabilitynexus-benefactionplatform-ergo-78.json
+++ b/submissions/stabilitynexus-benefactionplatform-ergo-78.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/StabilityNexus/BenefactionPlatform-Ergo/pull/175",
+  "work_title": "Find a bug in the contract: isWithdrawFunds terminates a project while the contract box is recreated",
+  "bounty_id": "StabilityNexus/BenefactionPlatform-Ergo#78",
+  "original_issue_link": "https://github.com/StabilityNexus/BenefactionPlatform-Ergo/issues/78",
+  "payment_currency": "BENE",
+  "bounty_value": 1000.0,
+  "status": "awaiting-review",
+  "submission_date": "2026-08-14",
+  "expected_completion": "2026-08-14",
+  "description": "Bug found and fixed in contracts/bene_contract/contract_v2.es. isReplicationBoxPresent only inspects OUTPUTS(0), so a guard written as !isReplicationBoxPresent can be satisfied while the contract box is in fact recreated at another output index; isWithdrawFunds could therefore terminate a project whose box still exists on chain. PR #174 adds a failing reproducible test, PR #175 the fix, as required by the issue.",
+  "review_notes": "Accepted by @0xf965 on 2026-08-14 on both PRs: 'Confirmed: this is a real bug and it is accepted' (#174) and 'The fix is correct and it is accepted' (#175). Award stated as 1000 BENE = 200 (bug found) + 800 (valid solution), per the two labels on issue #78. The reviewer also stated that the fix will NOT be merged into contract_v2.es: the frontend compiles that source at runtime to derive the template hash and the ErgoTree, so changing it would remove every live v2 project from the listing and invalidate transactions built for them, because the deployed contract requires sameScript. Ergo contracts are immutable and no migration is possible, which is why contract_v1_0.es and contract_v1_1.es also remain untouched in the repo. The fix goes into contract_v3.es with credit attributed there, and PR #175 stays open as the reference. So this submission is expected to be flagged 'upstream-unmerged' by triage: the linked PR will remain unmerged by maintainer decision, not because the work is incomplete.",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [ ] Completed claims link merged upstream work — **see below, this one cannot**
- [ ] Paid claims include `payment_tx_id` and `payment_date` — not paid yet

## The work

StabilityNexus/BenefactionPlatform-Ergo#78 asks for a bug in `contract_v2.es`, demonstrated by a reproducible failing test, plus a valid fix. Both are filed:

* **#174** — failing test. `isReplicationBoxPresent` only inspects `OUTPUTS(0)` (`contract_v2.es:70`), so a guard written as `!isReplicationBoxPresent` can hold while the contract box is in fact recreated at another output index. `isWithdrawFunds` could therefore terminate a project whose box still exists on chain.
* **#175** — the fix.

Both accepted by @0xf965 on 2026-08-14: *"Confirmed: this is a real bug and it is accepted"* and *"The fix is correct and it is accepted"*. Award stated as **1000 BENE = 200 (bug) + 800 (solution)**, matching the two labels on #78.

## Why the linked PR is not merged, and will not be

The triage bot will flag this `upstream-unmerged`. That is expected and it is not a defect in the work — the reviewer decided it explicitly:

> El fix es correcto y se acepta, pero no puede mergearse aquí.

The frontend compiles `contract_v2.es` at runtime to derive the template hash it searches the explorer with, and the ErgoTree it rebuilds boxes with on partial withdrawals. Changing the source changes the script, so every live v2 project would vanish from the listing and any transaction built for them would be invalid, because the deployed contract requires `sameScript`. Ergo contracts are immutable and there is no migration — which is why `contract_v1_0.es` and `contract_v1_1.es` also sit untouched in that repo.

The fix lands in `contract_v3.es` with credit attributed there; #175 stays open as the reference.

So the linked PR will remain open indefinitely by design. I have put the full reasoning in `review_notes` so whoever reviews this does not have to reconstruct it from the flag.

## A gap this exposes

There is no way to express *"accepted upstream, deliberately not merged"* in the current schema — `awaiting-review` plus an unmerged `work_link` is the closest, and it parks the claim in **Waiting Upstream** forever. Immutable contracts make this a recurring shape rather than a one-off, so it may be worth a status or a field. Related: #60. Happy to open a PR if you want it.