### PR TITLE
Add submission for bounty ergoplatform/ergo#1870

### DIFF
--- a/submissions/ergoplatform-ergo-1870.json
+++ b/submissions/ergoplatform-ergo-1870.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2458",
+  "work_title": "Consider slicing by height in /boxes/unspent",
+  "bounty_id": "ergoplatform/ergo#1870",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1870",
+  "payment_currency": "SigUSD",
+  "bounty_value": 500.0,
+  "status": "in-progress",
+  "submission_date": "2026-08-29",
+  "expected_completion": "2026-09-30",
+  "description": "Work implemented and submitted upstream: https://github.com/ergoplatform/ergo/pull/2458 (open, awaiting review). Re-files the reservation originally made on 2026-08-02 as PR #57: that PR was auto-closed on a spurious 'cannot parse JSON' triage error - the JSON parses and the branch merged clean against main.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Re-files the reservation for ergoplatform/ergo#1870 - "Consider slicing by height in /boxes/unspent" (500 SigUSD).

Work is implemented and submitted upstream as ergoplatform/ergo#2458 (open, awaiting review). Status stays `in-progress` until that PR merges; `expected_completion` set to 2026-09-30.

This replaces #57 (originally filed 2026-08-02), which the scheduled triage of 2026-08-28 closed with `invalid-json`. The JSON in that PR parses cleanly and its branch merges clean against `main`, so the label most likely came from a transient HTTP failure in `read_submission`, where any fetch error is reported as "cannot parse JSON". As the PR author I cannot reopen a bot-closed PR, hence this fresh submission. Happy to send a small patch separating fetch errors from parse errors if useful.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [ ] Completed claims use a GitHub PR URL in `work_link` (reservation: work_link points at the open upstream PR)
- [ ] Completed claims link merged upstream work (not yet merged)
- [ ] Paid claims include `payment_tx_id` and `payment_date` (n/a)

## Notes

Triage bot will label, comment, request review, and close invalid or stale submissions automatically.
