### PR TITLE
Create ergoplatform-ergo-1384.json (payment request, 1000 SigUSD)

### DIFF
--- a/submissions/ergoplatform-ergo-1384.json
+++ b/submissions/ergoplatform-ergo-1384.json
@@ -1,0 +1,18 @@
+{
+  "contributor": "Ergologica",
+  "wallet_address": "9g7wnNUa6tb69Rr3g6SHv8UxLHUjD2Sh4zwGEEdHWepv1EQftso",
+  "contact_method": "sullasoglia@proton.me",
+  "work_link": "https://github.com/ergoplatform/ergo/pull/2459",
+  "work_title": "Document interlinksProof in the PopowHeader schema",
+  "bounty_id": "ergoplatform/ergo#1384",
+  "original_issue_link": "https://github.com/ergoplatform/ergo/issues/1384",
+  "payment_currency": "SigUSD",
+  "bounty_value": 1000.0,
+  "status": "awaiting-review",
+  "submission_date": "2026-08-29",
+  "expected_completion": "2026-08-29",
+  "description": "PR ergoplatform/ergo#2459 (merged 2026-08-11, on master) closes the remaining gap of this issue: the interlinksProof field of PopowHeader is now documented in openapi.yaml. Full transparency for the reviewer: the substantive batch-proof implementation largely predates this and lives in PR #1526 by ApexTheory (open since 2021). I defer to the issue author on sizing the award - partial or zero is a legitimate outcome if the substantive work is credited elsewhere.",
+  "review_notes": "",
+  "payment_tx_id": "",
+  "payment_date": ""
+}


### PR DESCRIPTION
Payment request for ergoplatform/ergo#1384 - "Add proof that interlink vector corresponds to its header" (1000 SigUSD).

The linked work is ergoplatform/ergo#2459, merged 2026-08-11 on `master`: it documents the `interlinksProof` field of `PopowHeader` in `openapi.yaml`, closing the gap that remained open on this issue.

Full transparency for the reviewer: the substantive batch-proof implementation largely predates this and lives in ergoplatform/ergo#1526 by ApexTheory (open since 2021). I defer to the issue author on sizing the award - partial, or zero if the substantive work is credited elsewhere, are both legitimate outcomes. I am filing this so the bounty has a claim attached to merged work.

## Type

- [x] Bounty submission or reservation
- [ ] Automation/code change
- [ ] Generated data update
- [ ] Documentation

## Submission Checklist

- [x] One `submissions/*.json` file changed
- [x] `contributor` matches PR author
- [x] `wallet_address` is real, not placeholder
- [x] `status` is one of `in-progress`, `awaiting-review`, `reviewed`, `paid`
- [x] Completed claims use a GitHub PR URL in `work_link`
- [x] Completed claims link merged upstream work
- [ ] Paid claims include `payment_tx_id` and `payment_date` (n/a)

## Notes

Triage bot will label, comment, request review, and close invalid or stale submissions automatically.
